### PR TITLE
DownloadObject - Removed ListBuckets method

### DIFF
--- a/Frends.GoogleCloudStorage.DownloadObject/CHANGELOG.md
+++ b/Frends.GoogleCloudStorage.DownloadObject/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0]
+### Fixed
+- Fixed issue with ListBucket access policy by removing the ListBucket method and giving the bucket name directly to the FindMatchingFiles method.
+
 ## [1.0.0] - 2023-06-12
 ### Added
 - Initial implementation

--- a/Frends.GoogleCloudStorage.DownloadObject/CHANGELOG.md
+++ b/Frends.GoogleCloudStorage.DownloadObject/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.1.0]
+## [1.1.0] - 2025-06-18
 ### Fixed
 - Fixed issue with ListBucket access policy by removing the ListBucket method and giving the bucket name directly to the FindMatchingFiles method.
 

--- a/Frends.GoogleCloudStorage.DownloadObject/CHANGELOG.md
+++ b/Frends.GoogleCloudStorage.DownloadObject/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ## [1.1.0] - 2025-06-18
+### Removed
+- Eliminated the `ListBuckets` call used only for error handling. The bucket name is now passed directly to `FindMatchingFiles`.
+
 ### Fixed
-- Fixed issue with ListBucket access policy by removing the ListBucket method and giving the bucket name directly to the FindMatchingFiles method.
+- Access-policy failure when the `storage.buckets.list` permission is missing.
 
 ## [1.0.0] - 2023-06-12
 ### Added

--- a/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject.cs
+++ b/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject.cs
@@ -33,14 +33,10 @@ public class GoogleCloudStorage
 
         using var storage = await StorageClient.CreateAsync(googleCredential);
 
-        var bucket = storage.ListBuckets(input.ProjectId, null).FirstOrDefault(n => n.Name.Equals(input.BucketName)).Name;
-        if (string.IsNullOrEmpty(bucket))
-            throw new ArgumentException($"Bucket {input.BucketName} not found.");
-
-        var files = await FindMatchingFiles(storage, bucket, input.Pattern, cancellationToken);
+        var files = await FindMatchingFiles(storage, input.BucketName, input.Pattern, cancellationToken);
         var results = new List<Result>();
         foreach (var file in files)
-            results.Add(await ExecuteDownloadSingleObjectAsync(storage, file, bucket, input, cancellationToken));
+            results.Add(await ExecuteDownloadSingleObjectAsync(storage, file, input.BucketName, input, cancellationToken));
 
         return results;
     }

--- a/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject.csproj
+++ b/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.GoogleCloudStorage.DownloadObject</AssemblyName>
 	  <RootNamespace>Frends.GoogleCloudStorage.DownloadObject</RootNamespace>
 
-	  <Version>1.0.0</Version>
+	  <Version>1.0.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject.csproj
+++ b/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject/Frends.GoogleCloudStorage.DownloadObject.csproj
@@ -8,7 +8,7 @@
 	  <AssemblyName>Frends.GoogleCloudStorage.DownloadObject</AssemblyName>
 	  <RootNamespace>Frends.GoogleCloudStorage.DownloadObject</RootNamespace>
 
-	  <Version>1.0.1</Version>
+	  <Version>1.1.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Fixed issue with ListBuckets access rights by removing the method because the method was only used in error handling, which wasn't even needed. 

## [1.1.0] - 2025-06-18
### Fixed
- Fixed issue with ListBucket access policy by removing the ListBucket method and giving the bucket name directly to the FindMatchingFiles method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Google Cloud Storage bucket access by removing the need for ListBucket permissions. The bucket name is now used directly for file operations, which may resolve access issues for users with restricted permissions.

- **Documentation**
  - Updated the changelog to reflect the latest changes and fixes.

- **Chores**
  - Incremented the version number to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->